### PR TITLE
Nested published content data (issue#2)

### DIFF
--- a/src/Our.Umbraco.GraphQL/Types/ComplexGraphTypeOfIPublishedContentExtensions.cs
+++ b/src/Our.Umbraco.GraphQL/Types/ComplexGraphTypeOfIPublishedContentExtensions.cs
@@ -20,7 +20,7 @@ namespace Our.Umbraco.GraphQL.Types
         public static ComplexGraphType<IPublishedContent> AddUmbracoBuiltInProperties(this ComplexGraphType<IPublishedContent> graphType)
         {
             // TODO: set this field name as a reserved property alias
-            graphType.Field<BuildInContentDataGraphType>("_contentData", "Built in published content data.", resolve: context => context.Source);
+            graphType.Field<PublishedContentDataGraphType>("_contentData", "Built in published content data.", resolve: context => context.Source);
 
             return graphType;
         }

--- a/src/Our.Umbraco.GraphQL/Types/ComplexGraphTypeOfIPublishedContentExtensions.cs
+++ b/src/Our.Umbraco.GraphQL/Types/ComplexGraphTypeOfIPublishedContentExtensions.cs
@@ -19,6 +19,14 @@ namespace Our.Umbraco.GraphQL.Types
     {
         public static ComplexGraphType<IPublishedContent> AddUmbracoBuiltInProperties(this ComplexGraphType<IPublishedContent> graphType)
         {
+            // TODO: set this field name as a reserved property alias
+            graphType.Field<BuildInContentDataGraphType>("_contentData", "Built in published content data.", resolve: context => context.Source);
+
+            return graphType;
+        }
+
+        public static ComplexGraphType<IPublishedContent> AddContentDataProperties(this ComplexGraphType<IPublishedContent> graphType)
+        {
             //TODO: black/whitelist properties
             graphType.Field<NonNullGraphType<DateGraphType>>("createDate", "Create date of the content.");
             graphType.Field<NonNullGraphType<StringGraphType>>("creatorName", "Name of the content creator.");
@@ -47,13 +55,13 @@ namespace Our.Umbraco.GraphQL.Types
                         ? context.Source.AncestorsOrSelf()
                         : context.Source.Ancestors()).Filter(context).ToConnection(context)
                 );
-            
+
             graphType.FilteredConnection<PublishedContentGraphType, IPublishedContent>()
                 .Name("siblings")
                 .Description("Siblings of the content.")
                 .Bidirectional()
                 .Resolve(context => context.Source.Siblings().Filter(context).ToConnection(context));
-            
+
             graphType.FilteredConnection<PublishedContentGraphType, IPublishedContent>()
                 .Name("children")
                 .Description("Children of the content.")

--- a/src/Our.Umbraco.GraphQL/Types/PublishedContentGraphType.cs
+++ b/src/Our.Umbraco.GraphQL/Types/PublishedContentGraphType.cs
@@ -13,9 +13,9 @@ namespace Our.Umbraco.GraphQL.Types
         }
     }
 
-    public class BuildInContentDataGraphType : ObjectGraphType<IPublishedContent>
+    public class PublishedContentDataGraphType : ObjectGraphType<IPublishedContent>
     {
-        public BuildInContentDataGraphType()
+        public PublishedContentDataGraphType()
         {
             Name = "ContentData";
 

--- a/src/Our.Umbraco.GraphQL/Types/PublishedContentGraphType.cs
+++ b/src/Our.Umbraco.GraphQL/Types/PublishedContentGraphType.cs
@@ -17,7 +17,7 @@ namespace Our.Umbraco.GraphQL.Types
     {
         public PublishedContentDataGraphType()
         {
-            Name = "ContentData";
+            Name = "PublishedContentData";
 
             this.AddContentDataProperties();
         }

--- a/src/Our.Umbraco.GraphQL/Types/PublishedContentGraphType.cs
+++ b/src/Our.Umbraco.GraphQL/Types/PublishedContentGraphType.cs
@@ -12,4 +12,14 @@ namespace Our.Umbraco.GraphQL.Types
             this.AddUmbracoBuiltInProperties();
         }
     }
+
+    public class BuildInContentDataGraphType : ObjectGraphType<IPublishedContent>
+    {
+        public BuildInContentDataGraphType()
+        {
+            Name = "ContentData";
+
+            this.AddContentDataProperties();
+        }
+    }
 }


### PR DESCRIPTION
Nesting the base fields on IPublishedContent under _contentData to prevent it clashing with user created doctype aliases

This would change the current format from

```
{
  content(id:1123) {
    ...on Blogpost {
      pageTitle
      excerpt
      categories
      id
      createDate
      creatorName
      name
    }
  }
}
```
to

```
{
  content(id:1123) {
    ...on Blogpost {
      pageTitle
      excerpt
      categories
      _contentData {
        id
      	createDate
	creatorName
        name
    	}
    }
  }
}
```