### PR TITLE
Allow quering content by type

### DIFF
--- a/src/Our.Umbraco.GraphQL/Our.Umbraco.GraphQL.csproj
+++ b/src/Our.Umbraco.GraphQL/Our.Umbraco.GraphQL.csproj
@@ -256,6 +256,7 @@
     <Compile Include="Types\ConnectionExtensions.cs" />
     <Compile Include="Types\ConnectionWithFilterBuilder.cs" />
     <Compile Include="Types\PublishedContentAtRootQuery.cs" />
+    <Compile Include="Types\PublishedContentByTypeQuery.cs" />
     <Compile Include="Types\PublishedContentQuery.cs" />
     <Compile Include="Web\AppBuilderExtensions.cs" />
     <Compile Include="Web\GraphQLServerOptions.cs" />

--- a/src/Our.Umbraco.GraphQL/Types/PublishedContentByTypeQuery.cs
+++ b/src/Our.Umbraco.GraphQL/Types/PublishedContentByTypeQuery.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using GraphQL.Types;
+
+namespace Our.Umbraco.GraphQL.Types
+{
+    public class PublishedContentByTypeQuery : ObjectGraphType
+    {
+        public PublishedContentByTypeQuery(IEnumerable<IGraphType> documentGraphTypes)
+        {
+            Name = "PublishedContentByTypeQuery";
+
+            foreach (var type in documentGraphTypes)
+            {
+                string documentTypeAlias = type.GetMetadata<string>("documentTypeAlias");
+
+                Field<PublishedContentGraphType>()
+                    .Name(type.Name)
+                    .Argument<NonNullGraphType<IdGraphType>>("id", "The unique content id")
+                    .Type(type)
+                    .Resolve(context =>
+                    {
+                        var userContext = (UmbracoGraphQLContext)context.UserContext;
+                        var id = context.GetArgument<int>("id");
+                        return userContext.Umbraco.TypedContent(id);
+                    });
+            }
+        }
+    }
+}

--- a/src/Our.Umbraco.GraphQL/Types/PublishedContentQuery.cs
+++ b/src/Our.Umbraco.GraphQL/Types/PublishedContentQuery.cs
@@ -20,6 +20,11 @@ namespace Our.Umbraco.GraphQL.Types
                 });
 
             Field<NonNullGraphType<PublishedContentAtRootQuery>>()
+                .Name("byType")
+                .Resolve(context => context.ReturnType)
+                .Type(new NonNullGraphType(new PublishedContentByTypeQuery(documentGraphTypes)));
+
+            Field<NonNullGraphType<PublishedContentAtRootQuery>>()
                 .Name("atRoot")
                 .Resolve(context => context.ReturnType)
                 .Type(new NonNullGraphType(new PublishedContentAtRootQuery(documentGraphTypes)));


### PR DESCRIPTION
Added a new field `byType` on `content` which allows you to query for a specific document by it's type like this:

```graphql
{
  content {
    byType {
      Person(id: "1117") {
        photo {
          _contentData {
            url
          }
        }
        department
      }
    }
  }
}
```