### PR TITLE
Add by url query

### DIFF
--- a/src/Our.Umbraco.GraphQL/Types/PublishedContentQuery.cs
+++ b/src/Our.Umbraco.GraphQL/Types/PublishedContentQuery.cs
@@ -19,6 +19,31 @@ namespace Our.Umbraco.GraphQL.Types
                     return userContext.Umbraco.TypedContent(id);
                 });
 
+            Field<PublishedContentGraphType>()
+                .Name("byUrl")
+                .Argument<NonNullGraphType<StringGraphType>>("url", "The relative content url")
+                .Resolve(context =>
+                {
+                    var userContext = context.UmbracoUserContext();
+                    var url = context.GetArgument<string>("url");
+                    
+                    var pcr = new PublishedContentRequest(
+                        new Uri(userContext.RequestUri, url),
+                        userContext.UmbracoContext.RoutingContext,
+                        UmbracoConfig.For.UmbracoSettings().WebRouting,
+                        null
+                    );
+
+                    pcr.Prepare();
+
+                    if (pcr.IsRedirect || pcr.IsRedirectPermanent || pcr.Is404)
+                    {
+                        return null;
+                    }
+                    
+                    return pcr.PublishedContent;
+                });
+
             Field<NonNullGraphType<PublishedContentAtRootQuery>>()
                 .Name("atRoot")
                 .Resolve(context => context.ReturnType)


### PR DESCRIPTION
Added a new field `byUrl` on `content` which uses the Published Content Request pipeline to find the content by url relative to the current domain.

So for a multi site solution you'll get different results if you hit the graphql endpoint on each domain (if they're set on different nodes i Umbraco)

Example:
```graphql
{
  content {
    byUrl(url: "/"){
      _contentData {
        id
        name
      }
    }
  }
}
```